### PR TITLE
Browseable overview: Markdown + TOC (/overview)

### DIFF
--- a/docs/SiteOverview.md
+++ b/docs/SiteOverview.md
@@ -38,7 +38,9 @@ Point clients at the Spire instance you run; keys stay with participants per the
 
 ## Relationship to this website
 
-This page is **Markdown in the vex.wtf repo** (`public/docs/SiteOverview.md`), fetched by the browser and rendered with the same lightweight Markdown path as the privacy policy. Edit the file, merge, deploy — the overview updates with the site. For legal text that should live outside this repo, the privacy policy pattern (separate GitHub project + raw URL) still applies.
+This page is **Markdown in the vex.wtf repo** at [`docs/SiteOverview.md`](https://github.com/vex-protocol/vex.wtf/blob/master/docs/SiteOverview.md). The browser loads it from **GitHub raw** on `master`—the same idea as the privacy policy fetching from its own repo—and renders it with the same lightweight Markdown path used elsewhere on vex.wtf. Merge on GitHub to update copy; redeploy the site only when you change routing or rendering, not for every wording tweak.
+
+For legal text that should live outside this repo, the privacy policy pattern (separate GitHub project + raw URL) still applies.
 
 ## Defense- or sector-specific packets
 

--- a/public/docs/SiteOverview.md
+++ b/public/docs/SiteOverview.md
@@ -1,0 +1,45 @@
+# Vex at a glance
+
+**Private communications infrastructure** — your server, your keys, your stack.
+
+Vex is an open source end-to-end encrypted messaging protocol. You deploy the reference server, integrate the TypeScript client, and run the stack yourself so no third party sits in the message path.
+
+## Who this is for
+
+- **Product and platform teams** integrating encrypted chat or machine-to-machine messaging without routing traffic through a vendor cloud.
+- **Operators** who need a relay and policy surface they control: retention, export, and teardown follow **your** deployment and protocol settings, not a hosted console.
+- **Evaluators** who want a straight line from marketing claims to repos, docs, and security policy.
+
+## One stack, not two products
+
+The protocol has a single wire format end to end. The site highlights two **reference implementations** that ship together:
+
+- **Client library** — [`@vex-chat/libvex`](https://www.npmjs.com/package/@vex-chat/libvex) on npm, source at [`vex-protocol/libvex-js`](https://github.com/vex-protocol/libvex-js). Use it in apps, bots, and services that speak to your relay.
+- **Reference server** — [`@vex-chat/spire`](https://www.npmjs.com/package/@vex-chat/spire) on npm, source at [`vex-protocol/spire`](https://github.com/vex-protocol/spire). Deploy it as the relay and persistence layer next to your clients.
+
+The broader workspace (crypto, types, ops docs) lives in the [`vex-protocol`](https://github.com/vex-protocol/vex-protocol) monorepo.
+
+## Install quickly
+
+```bash
+npm install @vex-chat/libvex
+npm install @vex-chat/spire
+```
+
+Point clients at the Spire instance you run; keys stay with participants per the protocol design.
+
+## Where to read next
+
+- **Documentation** — [lib.vex.wtf](https://lib.vex.wtf/) (TypeScript client / integration).
+- **Security** — [SECURITY.md](https://github.com/vex-protocol/vex-protocol/blob/master/SECURITY.md) in the monorepo for coordinated disclosure.
+- **Licensing** — [Commercial licensing](/licensing) on this site; open source defaults are AGPL-oriented in the repos (see each package).
+- **Privacy** — [Privacy policy](/privacy-policy), maintained as Markdown in a dedicated GitHub repo (same rendering pipeline as this page).
+- **Status** — [Build and uptime-style status](/status).
+
+## Relationship to this website
+
+This page is **Markdown in the vex.wtf repo** (`public/docs/SiteOverview.md`), fetched by the browser and rendered with the same lightweight Markdown path as the privacy policy. Edit the file, merge, deploy — the overview updates with the site. For legal text that should live outside this repo, the privacy policy pattern (separate GitHub project + raw URL) still applies.
+
+## Defense- or sector-specific packets
+
+Higher-touch positioning (e.g. sector-specific capability packets) can live as separate Markdown or PDFs later, linked from here or from the homepage, without turning the public homepage into tactical copy.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,10 +27,14 @@ export function App(): JSX.Element {
     const [StatusPage, setStatusPage] = useState<ComponentType<{
         path?: string;
     }> | null>(null);
+    const [OverviewPage, setOverviewPage] = useState<ComponentType<{
+        path?: string;
+    }> | null>(null);
 
     useEffect(() => {
         if (
             HomePage ||
+            currentPath === "/overview" ||
             currentPath === "/privacy-policy" ||
             currentPath === "/licensing" ||
             currentPath === "/cla" ||
@@ -114,12 +118,31 @@ export function App(): JSX.Element {
         };
     }, [StatusPage, currentPath]);
 
+    useEffect(() => {
+        if (OverviewPage || currentPath !== "/overview") return;
+        let cancelled = false;
+        void import("./pages/OverviewPage").then((module) => {
+            if (!cancelled) {
+                setOverviewPage(() => module.OverviewPage);
+            }
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, [OverviewPage, currentPath]);
+
     return (
         <ClaSessionProvider>
             <div className="min-h-screen bg-zinc-950 text-zinc-100">
                 <Navbar currentPath={currentPath} />
                 <main className="mx-auto w-full max-w-5xl px-4 pb-16 pt-28 sm:px-6 lg:px-8">
-                    {currentPath === "/privacy-policy" ? (
+                    {currentPath === "/overview" ? (
+                        OverviewPage ? (
+                            <OverviewPage />
+                        ) : (
+                            <OverviewPageLoading />
+                        )
+                    ) : currentPath === "/privacy-policy" ? (
                         PrivacyPolicyPage ? (
                             <PrivacyPolicyPage />
                         ) : (
@@ -158,6 +181,17 @@ export function App(): JSX.Element {
                 <Footer />
             </div>
         </ClaSessionProvider>
+    );
+}
+
+function OverviewPageLoading(): JSX.Element {
+    return (
+        <RoutePanel splotch="soft">
+            <div className="inline-flex items-center gap-2.5 text-zinc-300">
+                <CrosshairSpinner className="text-zinc-200" />
+                <span>Loading overview</span>
+            </div>
+        </RoutePanel>
     );
 }
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,6 +7,7 @@ import { MenuIcon } from "./Icons";
 
 const LINKS = [
     { href: "/", label: "Home" },
+    { href: "/overview", label: "Overview" },
     { href: "/status", label: "Status" },
     { href: "/licensing", label: "Licensing" },
     { href: "/privacy-policy", label: "Privacy Policy" },

--- a/src/lib/quickMarkdown.tsx
+++ b/src/lib/quickMarkdown.tsx
@@ -1,7 +1,84 @@
 import { Fragment } from "preact";
 import type { ComponentChildren } from "preact";
 
-function parseInline(text: string): ComponentChildren[] {
+const DEFAULT_LINK_CLASS =
+    "text-red-200 underline decoration-red-400/60 underline-offset-4 hover:text-red-100";
+
+/** Neutral links for site-owned docs (e.g. `/overview`). */
+export const SITE_DOC_LINK_CLASS =
+    "text-zinc-200 underline decoration-white/25 underline-offset-4 hover:text-white";
+
+export type MarkdownTocItem = {
+    level: number;
+    text: string;
+    id: string;
+};
+
+type QuickMarkdownContext = {
+    linkClassName: string;
+    headingIdByLine: Map<number, string> | null;
+    headingAnchorOffset: boolean;
+};
+
+function stripInlineMd(s: string): string {
+    return s
+        .replace(/\*\*([^*]+)\*\*/g, "$1")
+        .replace(/\*([^*]+)\*/g, "$1")
+        .replace(/`([^`]+)`/g, "$1")
+        .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+}
+
+function slugifyForAnchor(s: string): string {
+    return stripInlineMd(s)
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9\s-]/g, "")
+        .replace(/\s+/g, "-")
+        .replace(/-+/g, "-")
+        .replace(/^-|-$/g, "");
+}
+
+function assignHeadingIds(lines: string[]): Map<number, string> {
+    const used = new Set<string>();
+    const map = new Map<number, string>();
+    for (let i = 0; i < lines.length; i++) {
+        const m = lines[i].match(/^(#{1,6})\s+(.+)$/);
+        if (!m) continue;
+        const plain = stripInlineMd(m[2]);
+        let base = slugifyForAnchor(plain);
+        if (!base) base = "section";
+        let slug = base;
+        let n = 2;
+        while (used.has(slug)) {
+            slug = `${base}-${n}`;
+            n++;
+        }
+        used.add(slug);
+        map.set(i, slug);
+    }
+    return map;
+}
+
+/** Build a table of contents from `##` / `###` (and deeper) headings; IDs match rendered heading `id`s. */
+export function buildMarkdownOutline(markdown: string): MarkdownTocItem[] {
+    const lines = markdown.replace(/\r\n/g, "\n").split("\n");
+    const idByLine = assignHeadingIds(lines);
+    const out: MarkdownTocItem[] = [];
+    for (let i = 0; i < lines.length; i++) {
+        const m = lines[i].match(/^(#{1,6})\s+(.+)$/);
+        if (!m) continue;
+        const id = idByLine.get(i);
+        if (!id) continue;
+        out.push({
+            level: m[1].length,
+            text: stripInlineMd(m[2]),
+            id,
+        });
+    }
+    return out;
+}
+
+function parseInline(text: string, ctx: QuickMarkdownContext): ComponentChildren[] {
     const pattern = /(`[^`]+`)|(\*\*[^*]+\*\*)|(\*[^*]+\*)|(\[[^\]]+\]\([^)]+\))/g;
     const nodes: ComponentChildren[] = [];
     let lastIndex = 0;
@@ -35,13 +112,16 @@ function parseInline(text: string): ComponentChildren[] {
         } else if (token.startsWith("[")) {
             const linkMatch = token.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
             if (linkMatch) {
+                const href = linkMatch[2];
+                const isExternal = /^https?:\/\//i.test(href);
                 nodes.push(
                     <a
                         key={`${match.index}-link`}
-                        href={linkMatch[2]}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-red-200 underline decoration-red-400/60 underline-offset-4 hover:text-red-100"
+                        href={href}
+                        {...(isExternal
+                            ? { target: "_blank", rel: "noreferrer" as const }
+                            : {})}
+                        className={ctx.linkClassName}
                     >
                         {linkMatch[1]}
                     </a>
@@ -61,17 +141,35 @@ function parseInline(text: string): ComponentChildren[] {
     return nodes;
 }
 
-function headingClass(level: number): string {
+function headingClass(level: number, anchorOffset: boolean): string {
+    const scroll = anchorOffset ? " scroll-mt-28" : "";
     if (level === 1)
-        return "mt-8 text-3xl font-bold tracking-tight text-zinc-50";
+        return `mt-8 text-3xl font-bold tracking-tight text-zinc-50${scroll}`;
     if (level === 2)
-        return "mt-7 text-2xl font-semibold tracking-tight text-zinc-50";
-    if (level === 3) return "mt-6 text-xl font-semibold text-zinc-100";
-    return "mt-5 text-lg font-semibold text-zinc-100";
+        return `mt-7 text-2xl font-semibold tracking-tight text-zinc-50${scroll}`;
+    if (level === 3) return `mt-6 text-xl font-semibold text-zinc-100${scroll}`;
+    return `mt-5 text-lg font-semibold text-zinc-100${scroll}`;
 }
 
-export function renderQuickMarkdown(markdown: string): ComponentChildren[] {
+export type RenderQuickMarkdownOptions = {
+    /** Defaults to policy-style red links. */
+    linkClassName?: string;
+    /** When false, headings do not get `id` attributes (legacy behavior). */
+    headingIds?: boolean;
+};
+
+export function renderQuickMarkdown(
+    markdown: string,
+    options?: RenderQuickMarkdownOptions
+): ComponentChildren[] {
     const lines = markdown.replace(/\r\n/g, "\n").split("\n");
+    const headingIds = options?.headingIds !== false;
+    const headingIdByLine = headingIds ? assignHeadingIds(lines) : null;
+    const ctx: QuickMarkdownContext = {
+        linkClassName: options?.linkClassName ?? DEFAULT_LINK_CLASS,
+        headingIdByLine,
+        headingAnchorOffset: Boolean(headingIdByLine),
+    };
     const result: ComponentChildren[] = [];
     let i = 0;
 
@@ -107,41 +205,43 @@ export function renderQuickMarkdown(markdown: string): ComponentChildren[] {
         const heading = raw.match(/^(#{1,6})\s+(.+)$/);
         if (heading) {
             const level = heading[1].length;
-            const content = parseInline(heading[2]);
-            const className = headingClass(level);
+            const content = parseInline(heading[2], ctx);
+            const className = headingClass(level, ctx.headingAnchorOffset);
+            const id = headingIdByLine?.get(i);
+            const idProp = id ? { id } : {};
             if (level === 1)
                 result.push(
-                    <h1 key={`h-${i}`} className={className}>
+                    <h1 key={`h-${i}`} className={className} {...idProp}>
                         {content}
                     </h1>
                 );
             else if (level === 2)
                 result.push(
-                    <h2 key={`h-${i}`} className={className}>
+                    <h2 key={`h-${i}`} className={className} {...idProp}>
                         {content}
                     </h2>
                 );
             else if (level === 3)
                 result.push(
-                    <h3 key={`h-${i}`} className={className}>
+                    <h3 key={`h-${i}`} className={className} {...idProp}>
                         {content}
                     </h3>
                 );
             else if (level === 4)
                 result.push(
-                    <h4 key={`h-${i}`} className={className}>
+                    <h4 key={`h-${i}`} className={className} {...idProp}>
                         {content}
                     </h4>
                 );
             else if (level === 5)
                 result.push(
-                    <h5 key={`h-${i}`} className={className}>
+                    <h5 key={`h-${i}`} className={className} {...idProp}>
                         {content}
                     </h5>
                 );
             else
                 result.push(
-                    <h6 key={`h-${i}`} className={className}>
+                    <h6 key={`h-${i}`} className={className} {...idProp}>
                         {content}
                     </h6>
                 );
@@ -168,7 +268,7 @@ export function renderQuickMarkdown(markdown: string): ComponentChildren[] {
                     key={`q-${i}`}
                     className="mt-5 border-l-2 border-red-300/70 pl-4 text-zinc-300"
                 >
-                    {parseInline(quoteLines.join(" "))}
+                    {parseInline(quoteLines.join(" "), ctx)}
                 </blockquote>
             );
             continue;
@@ -187,7 +287,9 @@ export function renderQuickMarkdown(markdown: string): ComponentChildren[] {
                     className="mt-4 list-disc space-y-1 pl-6 text-zinc-200"
                 >
                     {items.map((item, index) => (
-                        <li key={`ul-${i}-${index}`}>{parseInline(item)}</li>
+                        <li key={`ul-${i}-${index}`}>
+                            {parseInline(item, ctx)}
+                        </li>
                     ))}
                 </ul>
             );
@@ -207,7 +309,9 @@ export function renderQuickMarkdown(markdown: string): ComponentChildren[] {
                     className="mt-4 list-decimal space-y-1 pl-6 text-zinc-200"
                 >
                     {items.map((item, index) => (
-                        <li key={`ol-${i}-${index}`}>{parseInline(item)}</li>
+                        <li key={`ol-${i}-${index}`}>
+                            {parseInline(item, ctx)}
+                        </li>
                     ))}
                 </ol>
             );
@@ -233,7 +337,7 @@ export function renderQuickMarkdown(markdown: string): ComponentChildren[] {
 
         result.push(
             <p key={`p-${i}`} className="mt-4 leading-7 text-zinc-200">
-                {parseInline(paragraphLines.join(" "))}
+                {parseInline(paragraphLines.join(" "), ctx)}
             </p>
         );
     }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -332,6 +332,9 @@ function HomeResourceLinks(): JSX.Element {
             className="mt-6 flex flex-wrap gap-2"
             aria-label="Documentation, source, and policies"
         >
+            <a href="/overview" className={STACK_LINK_CLASS}>
+                Overview →
+            </a>
             <a
                 href={DOCS_URL}
                 target="_blank"

--- a/src/pages/OverviewPage.tsx
+++ b/src/pages/OverviewPage.tsx
@@ -8,11 +8,12 @@ import {
     type MarkdownTocItem,
 } from "../lib/quickMarkdown";
 
-/** Versioned with the site (`public/docs/`); same-origin fetch, no GitHub API. */
-const SITE_OVERVIEW_MD_URL = "/docs/SiteOverview.md";
+/** Canonical Markdown on `master` (same pattern as privacy policy). */
+const SITE_OVERVIEW_RAW_URL =
+    "https://raw.githubusercontent.com/vex-protocol/vex.wtf/master/docs/SiteOverview.md";
 
 const SITE_OVERVIEW_EDIT_ON_GITHUB =
-    "https://github.com/vex-protocol/vex.wtf/blob/master/public/docs/SiteOverview.md";
+    "https://github.com/vex-protocol/vex.wtf/blob/master/docs/SiteOverview.md";
 
 export function OverviewPage(_: { path?: string }): JSX.Element {
     const [markdown, setMarkdown] = useState("");
@@ -25,7 +26,7 @@ export function OverviewPage(_: { path?: string }): JSX.Element {
         async function load() {
             try {
                 setStatus("loading");
-                const response = await fetch(SITE_OVERVIEW_MD_URL);
+                const response = await fetch(SITE_OVERVIEW_RAW_URL);
                 if (!response.ok) {
                     throw new Error(String(response.status));
                 }

--- a/src/pages/OverviewPage.tsx
+++ b/src/pages/OverviewPage.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState } from "preact/hooks";
+import { CrosshairSpinner } from "../components/CrosshairSpinner";
+import { RoutePanel } from "../components/RoutePanel";
+import {
+    buildMarkdownOutline,
+    renderQuickMarkdown,
+    SITE_DOC_LINK_CLASS,
+    type MarkdownTocItem,
+} from "../lib/quickMarkdown";
+
+/** Versioned with the site (`public/docs/`); same-origin fetch, no GitHub API. */
+const SITE_OVERVIEW_MD_URL = "/docs/SiteOverview.md";
+
+const SITE_OVERVIEW_EDIT_ON_GITHUB =
+    "https://github.com/vex-protocol/vex.wtf/blob/master/public/docs/SiteOverview.md";
+
+export function OverviewPage(_: { path?: string }): JSX.Element {
+    const [markdown, setMarkdown] = useState("");
+    const [toc, setToc] = useState<MarkdownTocItem[]>([]);
+    const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+
+    useEffect(() => {
+        let cancelled = false;
+
+        async function load() {
+            try {
+                setStatus("loading");
+                const response = await fetch(SITE_OVERVIEW_MD_URL);
+                if (!response.ok) {
+                    throw new Error(String(response.status));
+                }
+                const text = await response.text();
+                if (!cancelled) {
+                    setMarkdown(text);
+                    setToc(
+                        buildMarkdownOutline(text).filter(
+                            (item) => item.level >= 2 && item.level <= 3
+                        )
+                    );
+                    setStatus("idle");
+                }
+            } catch {
+                if (!cancelled) {
+                    setStatus("error");
+                }
+            }
+        }
+
+        void load();
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    return (
+        <RoutePanel splotch="soft">
+            {status === "loading" ? (
+                <div className="inline-flex items-center gap-2.5 text-zinc-300">
+                    <CrosshairSpinner className="text-zinc-200" />
+                    <span>Loading overview</span>
+                </div>
+            ) : null}
+
+            {status === "error" ? (
+                <p className="text-red-300">
+                    Could not load the overview document. Try again later or open
+                    the source on{" "}
+                    <a
+                        href={SITE_OVERVIEW_EDIT_ON_GITHUB}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="underline decoration-red-400/60 underline-offset-2 hover:text-red-200"
+                    >
+                        GitHub
+                    </a>
+                    .
+                </p>
+            ) : null}
+
+            {status === "idle" && markdown ? (
+                <div className="lg:grid lg:grid-cols-[minmax(0,13rem)_minmax(0,1fr)] lg:items-start lg:gap-10">
+                    {toc.length > 0 ? (
+                        <MarkdownTocNav items={toc} />
+                    ) : null}
+                    <div className="min-w-0">
+                        <p className="mt-0 text-sm text-zinc-500">
+                            Browseable overview ·{" "}
+                            <a
+                                href={SITE_OVERVIEW_EDIT_ON_GITHUB}
+                                target="_blank"
+                                rel="noreferrer"
+                                className="text-zinc-400 underline decoration-white/20 underline-offset-2 hover:text-zinc-200"
+                            >
+                                Edit on GitHub
+                            </a>
+                        </p>
+                        <article className="max-w-none [&>h1:first-of-type]:mt-2 [&>h1:first-of-type]:text-2xl [&>h1:first-of-type]:font-bold [&>h1:first-of-type]:tracking-tight sm:[&>h1:first-of-type]:text-3xl [&>p:first-of-type]:mt-0">
+                            {renderQuickMarkdown(markdown, {
+                                linkClassName: SITE_DOC_LINK_CLASS,
+                            })}
+                        </article>
+                    </div>
+                </div>
+            ) : null}
+        </RoutePanel>
+    );
+}
+
+function MarkdownTocNav(props: { items: MarkdownTocItem[] }): JSX.Element {
+    return (
+        <nav
+            className="mb-8 lg:sticky lg:top-28 lg:mb-0"
+            aria-label="On this page"
+        >
+            <p className="text-[0.6875rem] font-semibold uppercase tracking-[0.14em] text-zinc-500">
+                On this page
+            </p>
+            <ul className="mt-2 space-y-1 border-l border-white/10 pl-3">
+                {props.items.map((item) => (
+                    <li
+                        key={item.id}
+                        className="list-none"
+                        style={{
+                            paddingLeft: `${Math.max(0, item.level - 2) * 0.65}rem`,
+                        }}
+                    >
+                        <a
+                            href={`#${item.id}`}
+                            className="block py-0.5 text-sm leading-snug text-zinc-400 transition hover:text-zinc-100"
+                        >
+                            {item.text}
+                        </a>
+                    </li>
+                ))}
+            </ul>
+        </nav>
+    );
+}


### PR DESCRIPTION
## Summary
Adds an **easily browseable** long-form view of the thesis and evaluator paths, reusing the same `renderQuickMarkdown` pipeline as the privacy policy.

## Approach
- **Content:** `public/docs/SiteOverview.md` — versioned with the site, fetched at runtime from `/docs/SiteOverview.md` (same-origin, no GitHub API or CORS). **Edit on GitHub** points at the blob URL in this repo.
- **Browseability:** `buildMarkdownOutline()` + stable `id` on headings; sticky **On this page** sidebar (h2–h3) on large screens; `scroll-mt-28` on headings for the fixed nav.
- **Markdown renderer:** heading anchors apply to all pages using `renderQuickMarkdown` (privacy, CLA, overview). Optional `linkClassName`; overview uses neutral site-doc links. `http(s)` links still open in a new tab; relative links do not.

## Alternative (not implemented)
To mirror the privacy policy **exactly** (raw `githubusercontent.com` from another branch/repo), change `SITE_OVERVIEW_MD_URL` in `OverviewPage.tsx` to a raw URL — tradeoff: content updates only after that repo merges, and cold-cache 404 until first publish.

## Routes / nav
- New route: `/overview`
- Navbar **Overview**; homepage resource row **Overview →**

## Test plan
- [x] `npm run build` (confirms `dist/docs/SiteOverview.md` exists)

Made with [Cursor](https://cursor.com)