### PR TITLE
[codex] Add invite link handoff page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,10 @@ export function App(): JSX.Element {
     const [StatusPage, setStatusPage] = useState<ComponentType<{
         path?: string;
     }> | null>(null);
+    const [InviteRedirectPage, setInviteRedirectPage] = useState<ComponentType<{
+        path?: string;
+    }> | null>(null);
+    const isInviteRoute = currentPath.startsWith("/invite/");
 
     useEffect(() => {
         if (
@@ -35,7 +39,8 @@ export function App(): JSX.Element {
             currentPath === "/licensing" ||
             currentPath === "/cla" ||
             currentPath === "/cla-admin" ||
-            currentPath === "/status"
+            currentPath === "/status" ||
+            isInviteRoute
         )
             return;
         let cancelled = false;
@@ -47,7 +52,7 @@ export function App(): JSX.Element {
         return () => {
             cancelled = true;
         };
-    }, [HomePage, currentPath]);
+    }, [HomePage, currentPath, isInviteRoute]);
 
     useEffect(() => {
         if (PrivacyPolicyPage || currentPath !== "/privacy-policy") return;
@@ -114,6 +119,19 @@ export function App(): JSX.Element {
         };
     }, [StatusPage, currentPath]);
 
+    useEffect(() => {
+        if (InviteRedirectPage || !isInviteRoute) return;
+        let cancelled = false;
+        void import("./pages/InviteRedirectPage").then((module) => {
+            if (!cancelled) {
+                setInviteRedirectPage(() => module.InviteRedirectPage);
+            }
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, [InviteRedirectPage, isInviteRoute]);
+
     return (
         <ClaSessionProvider>
             <div className="min-h-screen bg-zinc-950 text-zinc-100">
@@ -148,6 +166,12 @@ export function App(): JSX.Element {
                             <StatusPage />
                         ) : (
                             <StatusPageLoading />
+                        )
+                    ) : isInviteRoute ? (
+                        InviteRedirectPage ? (
+                            <InviteRedirectPage path={currentPath} />
+                        ) : (
+                            <InviteRedirectLoading />
                         )
                     ) : HomePage ? (
                         <HomePage />
@@ -222,6 +246,17 @@ function StatusPageLoading(): JSX.Element {
             <div className="inline-flex items-center gap-2.5 text-zinc-300">
                 <CrosshairSpinner className="text-zinc-200" />
                 <span>Loading status</span>
+            </div>
+        </RoutePanel>
+    );
+}
+
+function InviteRedirectLoading(): JSX.Element {
+    return (
+        <RoutePanel splotch="home">
+            <div className="inline-flex items-center gap-2.5 text-zinc-300">
+                <CrosshairSpinner className="text-zinc-200" />
+                <span>Opening invite</span>
             </div>
         </RoutePanel>
     );

--- a/src/pages/InviteRedirectPage.tsx
+++ b/src/pages/InviteRedirectPage.tsx
@@ -1,0 +1,96 @@
+import type { JSX } from "preact";
+
+import { useEffect, useMemo, useState } from "preact/hooks";
+
+import { RoutePanel } from "../components/RoutePanel";
+
+const UUID_PATTERN =
+    "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+const INVITE_PATH_RE = new RegExp(`^/invite/(${UUID_PATTERN})/?$`, "i");
+
+export function InviteRedirectPage(props: { path?: string }): JSX.Element {
+    const inviteID = parseInviteID(props.path ?? window.location.pathname);
+    const appLink = useMemo(
+        () => (inviteID ? formatInviteAppLink(inviteID) : null),
+        [inviteID]
+    );
+    const [copied, setCopied] = useState(false);
+
+    useEffect(() => {
+        if (!appLink) return;
+        const timer = window.setTimeout(() => {
+            window.location.href = appLink;
+        }, 250);
+        return () => window.clearTimeout(timer);
+    }, [appLink]);
+
+    const copyInvite = async () => {
+        if (!inviteID || !navigator.clipboard) return;
+        await navigator.clipboard.writeText(inviteID);
+        setCopied(true);
+        window.setTimeout(() => setCopied(false), 1800);
+    };
+
+    if (!inviteID || !appLink) {
+        return (
+            <RoutePanel splotch="soft">
+                <p className="text-xs uppercase tracking-[0.18em] text-[#ff6b6b]">
+                    Invite
+                </p>
+                <h1 className="mt-3 text-2xl font-bold tracking-tight text-zinc-50 sm:text-3xl">
+                    Invalid invite link
+                </h1>
+                <p className="mt-4 max-w-2xl text-base leading-relaxed text-zinc-300 sm:text-lg">
+                    This invite URL is missing a valid invite code.
+                </p>
+                <p className="mt-6">
+                    <a
+                        href="/"
+                        className="inline-flex rounded-lg border border-white/15 bg-white/5 px-4 py-3 text-sm font-medium text-zinc-100 no-underline transition-colors hover:border-white/25 hover:bg-white/10"
+                    >
+                        Back to Vex
+                    </a>
+                </p>
+            </RoutePanel>
+        );
+    }
+
+    return (
+        <RoutePanel splotch="home">
+            <p className="text-xs uppercase tracking-[0.18em] text-[#ff6b6b]">
+                Server invite
+            </p>
+            <h1 className="mt-3 text-2xl font-bold tracking-tight text-zinc-50 sm:text-3xl">
+                Opening Vex
+            </h1>
+            <p className="mt-4 max-w-2xl text-base leading-relaxed text-zinc-300 sm:text-lg">
+                Your invite is ready. If Vex does not open automatically, use
+                the button below.
+            </p>
+            <div className="mt-7 flex flex-wrap items-center gap-3">
+                <a
+                    href={appLink}
+                    className="inline-flex rounded-lg border border-[#e70000]/50 bg-[#e70000]/20 px-4 py-3 text-sm font-semibold text-[#ff8a8a] no-underline transition-colors hover:border-[#e70000]/70 hover:bg-[#e70000]/30"
+                >
+                    Open in Vex
+                </a>
+                <button
+                    type="button"
+                    onClick={() => void copyInvite()}
+                    className="inline-flex rounded-lg border border-white/15 bg-white/5 px-4 py-3 text-sm font-medium text-zinc-100 transition-colors hover:border-white/25 hover:bg-white/10"
+                >
+                    {copied ? "Copied" : "Copy invite code"}
+                </button>
+            </div>
+            <p className="mt-6 font-mono text-xs text-zinc-500">{inviteID}</p>
+        </RoutePanel>
+    );
+}
+
+function formatInviteAppLink(inviteID: string): string {
+    return `vex://invite/${inviteID}`;
+}
+
+function parseInviteID(path: string): null | string {
+    return INVITE_PATH_RE.exec(path)?.[1] ?? null;
+}


### PR DESCRIPTION
## Summary

- Adds `/invite/:inviteID` routing to the vex.wtf site.
- Automatically attempts to open the installed app with `vex://invite/:inviteID`.
- Provides fallback controls to manually open the app URI or copy the invite code.

## Validation

- `npm test`
- `npm run build`
- `git diff --check`
- Local dev route checked at `/invite/3f2ae9b8-c5a7-4d4a-9f3e-1a2b3c4d5e6f`